### PR TITLE
Improve Streamlit Sandmännchen app visuals and playback

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+requests
+pandas


### PR DESCRIPTION
## Summary
- Add Sandmännchen banner image and custom CSS for a cleaner layout
- Display episodes in a styled table with links and expandable in-page video players
- Include requirements file for Streamlit, requests, and pandas

## Testing
- `python -m py_compile stream.app.peskowcik.py`


------
https://chatgpt.com/codex/tasks/task_e_68af33386a8c832d93e769ca6fcc7822