### PR TITLE
Add manual fallback for Aug 3, 2025 Pěskowčik episode

### DIFF
--- a/stream.app.peskowcik.py
+++ b/stream.app.peskowcik.py
@@ -367,8 +367,18 @@ MANUAL_EPISODES: List[str] = [
     # Pěskowčik: Liška a sroka: Špewaca lisca wopus | 06.07.2025
     "Y3JpZDovL3JiYl8xNDYwZDFhZS1hYTBkLTQ5YjctYTRlYy1kZDZiOWVmNjI1OWRfcHVibGljYXRpb24",
 
+    # Pěskowčik: Plumps: Powetrowy balon | 13.07.2025
+    "Y3JpZDovL3JiYl80MzU4NjU4Ny1jZDk3LTQ4MTEtYWFkNS05YWMzYmJjZWY3OGVfcHVibGljYXRpb24",
+    # Pěskowčik: Plumps: Jako chcyše ćipka wulka być | 27.07.2025
+    "Y3JpZDovL3JiYl9kNGU3YTc0Mi1jYzEzLTRjNTYtYjVkYS01OWQ5MmFkZjJjZDlfcHVibGljYXRpb24",
+    # Pěskowčik: Liška a sroka: Překwapjenka za knjeni sroku | 03.08.2025
+    "Y3JpZDovL3JiYl82NjM2ZDcxZS0zYzZjLTRjYTUtOGI1ZS0yNjc0OTQxMjQ0ZWZfcHVibGljYXRpb24",
+    # Pěskowčik: Plumps: Der Glückskäfer | 10.08.2025
+    "Y3JpZDovL3JiYl84OWJjODc4Mi01MWYwLTQ2NzgtYmM5MC1mYzIxMzNkOTIyOWFfcHVibGljYXRpb24",
     # Fuchs und Elster: Gestörte Angelfreuden (sorbisch) | 24.08.2025
     "Y3JpZDovL3JiYl80MDE1ZGU4MS01ZjQwLTRhOWItYjdlNi1kZTQ3ZGU2M2Y5MTVfcHVibGljYXRpb24",
+    # Pěskowčik: Pitiplac mopi a knyskotaty law | 31.08.2025
+    "Y3JpZDovL3JiYl81NTY3M2M5Zi01YjAyLTQ5OTQtOTI1Ny1lMjk5MjdlMjNhNjZfcHVibGljYXRpb24",
 ]
 
 # Optional additional sources (URLs) that might not show up in MediathekView yet.
@@ -379,8 +389,9 @@ MANUAL_EPISODE_URLS: List[str] = [
     "https://www.mdr.de/sandmann/video-536936.html",
     "https://www.mdr.de/sandmann/video-529286.html",
     "https://www.mdr.de/sandmann/video-529344.html",
-    # Provided by user: ARD Mediathek direct link (already contains base64 ID)
+    # Provided by user: ARD Mediathek direct links (already contain base64 ID)
     "https://www.ardmediathek.de/video/unser-sandmaennchen/peskowcik-liska-a-sroka-jablucina-oder-unser-sandmaennchen-sorbisch-oder-17-08-2025/rbb/Y3JpZDovL3JiYl9iNmY2MWU1ZC02NDdkLTQ2ZjQtYjYzNC0wY2JkOTM5NzYwOTdfcHVibGljYXRpb24",
+    "https://www.ardmediathek.de/video/unser-sandmaennchen/peskowcik-liska-a-sroka-prekwapjenka-za-knjeni-sroku-oder-unser-sandmaennchen-sorbisch-oder-03-08-2025/rbb/Y3JpZDovL3JiYl82NjM2ZDcxZS0zYzZjLTRjYTUtOGI1ZS0yNjc0OTQxMjQ0ZWZfcHVibGljYXRpb24",
 ]
 
 # Rich metadata for specific MDR links provided by the user.


### PR DESCRIPTION
## Summary
- include ARD Mediathek URL for 3 Aug 2025 "Liška a sroka" episode in `MANUAL_EPISODE_URLS` so it's loaded even if the API misses it

## Testing
- `python -m py_compile stream.app.peskowcik.py`


------
https://chatgpt.com/codex/tasks/task_e_68b88f9a1684832db1bff47ca6b1a4e8